### PR TITLE
Fix tests and add coverage

### DIFF
--- a/app/src/lib/bing.test.ts
+++ b/app/src/lib/bing.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fetchBingImages } from './bing.js';
+
+vi.mock('axios');
+
+const sample = {
+  startdate: '20250721',
+  url: 'https://img.jpg',
+  copyright: 'c',
+  title: 't'
+};
+
+describe('fetchBingImages', () => {
+  it('returns images when request succeeds', async () => {
+    const axios = await import('axios');
+    (axios.default.get as any) = vi.fn(async () => ({ status: 200, data: { images: [sample] } }));
+    const res = await fetchBingImages();
+    expect(res[0].startdate).toBe('20250721');
+  });
+
+  it('throws on invalid response', async () => {
+    const axios = await import('axios');
+    (axios.default.get as any) = vi.fn(async () => ({ status: 200, data: {} }));
+    await expect(fetchBingImages()).rejects.toThrow('invalid response');
+  });
+});

--- a/app/src/services/wallpaperService.test.ts
+++ b/app/src/services/wallpaperService.test.ts
@@ -8,6 +8,7 @@ vi.mock('fs-extra', () => ({
   readFile: vol.promises.readFile,
   writeFile: vol.promises.writeFile,
 }));
+vi.mock('node:fs/promises', () => vol.promises);
 
 vi.mock('../lib/bing.js', () => ({
   fetchBingImages: vi.fn(() => Promise.resolve([sampleImage]))
@@ -32,10 +33,10 @@ describe('wallpaperService', () => {
   });
 
   it('saves images from migrate plugin', async () => {
-    const fs = await import('fs/promises');
-    const dir = await fs.mkdtemp('/tmp-plugin-');
+    const fs = await import('fs');
+    const dir = await fs.promises.mkdtemp('/tmp-plugin-');
     const pluginPath = `${dir}/p.mjs`;
-    await fs.writeFile(pluginPath, 'export default async () => [' + JSON.stringify(sampleImage) + '];');
+    await fs.promises.writeFile(pluginPath, 'export default async () => [' + JSON.stringify(sampleImage) + '];');
     await migrateWallpapers(pluginPath, 'src');
     const file = wallpaperPath('20250721');
     const text = await vol.promises.readFile(file, 'utf8');

--- a/app/src/services/wallpaperService.ts
+++ b/app/src/services/wallpaperService.ts
@@ -23,7 +23,7 @@ export async function updateWallpapers() {
 }
 
 export async function migrateWallpapers(plugin: string, source: string, opts: SaveOptions = {}) {
-  const mod = await import(pathToFileURL(plugin).href);
+  const mod = await import(/* @vite-ignore */ pathToFileURL(plugin).href);
   const loader: (src: string) => Promise<BingImage[]> = mod.default;
   const images = await loader(source);
   await saveImages(images, opts);


### PR DESCRIPTION
## Summary
- fix mocking paths in wallpaperService tests
- update dynamic plugin import to ignore vite bundler
- add tests for the bing image fetcher

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm coverage`

------
https://chatgpt.com/codex/tasks/task_e_6882926c5de883278173bfda8c771efe