### PR TITLE
Refine archive utilities

### DIFF
--- a/app/src/cli.ts
+++ b/app/src/cli.ts
@@ -4,6 +4,7 @@ import { updateCommand } from './commands/update.js';
 import { migrateCommand } from './commands/migrate.js';
 import { buildIndexCommand } from './commands/buildIndex.js';
 import { buildArchiveCommand } from './commands/buildArchive.js';
+import { uploadCommand } from './commands/upload.js';
 
 const program = new Command();
 
@@ -45,6 +46,15 @@ program
   .description('generate README and archives')
   .action(async () => {
     await buildArchiveCommand();
+  });
+
+program
+  .command('upload')
+  .description('upload images to S3')
+  .option('--bucket <name>', 'bucket name')
+  .option('--cursor <key>', 'cursor key', 'cursor.txt')
+  .action(async (opts) => {
+    await uploadCommand({ bucket: opts.bucket, cursor: opts.cursor });
   });
 
 program.parseAsync(process.argv);

--- a/app/src/commands/upload.ts
+++ b/app/src/commands/upload.ts
@@ -1,0 +1,10 @@
+import { uploadImages } from '../services/uploadService.js';
+
+export interface UploadOptions {
+  bucket: string;
+  cursor?: string;
+}
+
+export async function uploadCommand(opts: UploadOptions) {
+  await uploadImages({ bucket: opts.bucket, cursorKey: opts.cursor });
+}

--- a/app/src/lib/bing.test.ts
+++ b/app/src/lib/bing.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fetchBingImages } from './bing.js';
+
+vi.mock('axios');
+
+const sample = {
+  startdate: '20250721',
+  url: 'https://img.jpg',
+  copyright: 'c',
+  title: 't'
+};
+
+describe('fetchBingImages', () => {
+  it('returns images when request succeeds', async () => {
+    const axios = await import('axios');
+    (axios.default.get as any) = vi.fn(async () => ({ status: 200, data: { images: [sample] } }));
+    const res = await fetchBingImages();
+    expect(res[0].startdate).toBe('20250721');
+  });
+
+  it('throws on invalid response', async () => {
+    const axios = await import('axios');
+    (axios.default.get as any) = vi.fn(async () => ({ status: 200, data: {} }));
+    await expect(fetchBingImages()).rejects.toThrow('invalid response');
+  });
+});

--- a/app/src/models/dailyMarkdown.test.ts
+++ b/app/src/models/dailyMarkdown.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { vol } from 'memfs';
+
+vi.mock('fs-extra', () => ({
+  ensureDir: async (p: string) => vol.promises.mkdir(p, { recursive: true }),
+  readFile: vol.promises.readFile,
+  writeFile: vol.promises.writeFile,
+}));
+vi.mock('node:fs/promises', () => vol.promises);
+
+import { DailyMarkdown } from './dailyMarkdown.js';
+import type { WallpaperMeta } from '../repositories/wallpaperRepository.js';
+
+const meta: WallpaperMeta = {
+  previewUrl: 'https://p/prev.jpg',
+  downloadUrl: 'https://p/dl.jpg?id=foo',
+  bing: { startdate: '20250721', url: 'https://p/dl.jpg', title: 't', copyright: 'c' },
+};
+
+describe('DailyMarkdown', () => {
+  it('computes paths and index lines', async () => {
+    const daily = new DailyMarkdown('20250721', meta);
+    expect(daily.year).toBe('2025');
+    expect(daily.month).toBe('07');
+    expect(daily.day).toBe('21');
+    expect(daily.monthKey).toBe('2025-07');
+    expect(daily.monthPath).toBe('2025/07');
+    expect(daily.monthDir).toBe('wallpaper/2025/07');
+    expect(daily.file).toMatch('2025/07/21.md');
+    const line = daily.indexLine();
+    expect(line).toContain('2025/07/21.md');
+    expect(line).toContain(meta.downloadUrl);
+    await daily.save();
+    const saved = await vol.promises.readFile(daily.file, 'utf8');
+    expect(saved).toContain('Download 4k');
+  });
+
+  it('parses index lines', () => {
+    const res = DailyMarkdown.parseIndexLine('2025/07/21.md https://x?id=foo');
+    expect(res.key).toBe('2025/07/21/foo');
+    expect(res.date).toBe('2025/07/21');
+  });
+});

--- a/app/src/models/dailyMarkdown.ts
+++ b/app/src/models/dailyMarkdown.ts
@@ -1,0 +1,85 @@
+import { join, relative } from 'node:path';
+import matter from 'gray-matter';
+import { DIR_WALLPAPER } from '../lib/config.js';
+import type { WallpaperMeta, WallpaperRecord } from '../repositories/wallpaperRepository.js';
+import { wallpaperPath, saveWallpaper, readWallpaper } from '../repositories/wallpaperRepository.js';
+
+export class DailyMarkdown {
+  constructor(public date: string, public meta: WallpaperMeta) {}
+
+  static fromRecord(rec: WallpaperRecord): DailyMarkdown {
+    return new DailyMarkdown(rec.date, rec.meta);
+  }
+
+  static async fromFile(file: string): Promise<DailyMarkdown> {
+    const rec = await readWallpaper(file);
+    return new DailyMarkdown(rec.date, rec.meta);
+  }
+
+  get year(): string {
+    return this.date.slice(0, 4);
+  }
+
+  get month(): string {
+    return this.date.slice(4, 6);
+  }
+
+  /**
+   * year/month folder relative to wallpaper directory
+   */
+  get monthPath(): string {
+    return join(this.year, this.month);
+  }
+
+  /**
+   * YYYY-MM segment used for archive grouping
+   */
+  get monthKey(): string {
+    return `${this.year}-${this.month}`;
+  }
+
+  get day(): string {
+    return this.date.slice(6);
+  }
+
+  get file(): string {
+    return wallpaperPath(this.date);
+  }
+
+  /**
+   * Absolute directory path for the month
+   */
+  get monthDir(): string {
+    return join(DIR_WALLPAPER, this.monthPath);
+  }
+
+  /**
+   * Format the entry for all.txt or current.txt
+   */
+  indexLine(): string {
+    return `${relative(DIR_WALLPAPER, this.file)} ${this.meta.downloadUrl}`;
+  }
+
+  async save(): Promise<string> {
+    return saveWallpaper(this.meta, this.date);
+  }
+
+  /**
+   * Generate markdown content including front matter
+   */
+  content(): string {
+    const body = `# ${this.meta.bing.title}\n\n${this.meta.bing.copyright ?? ''}\n\n` +
+      `![${this.meta.bing.title}](${this.meta.previewUrl})\n\n` +
+      `Date: ${this.year}-${this.month}-${this.day}\n\n` +
+      `Download 4k: [${this.meta.bing.title}](${this.meta.downloadUrl})\n`;
+    return matter.stringify(body, this.meta);
+  }
+
+
+  static parseIndexLine(line: string): { date: string; url: string; key: string } {
+    const [path, url] = line.split(' ').map((s) => s.trim());
+    const date = path.replace(/\.md$/, '');
+    const id = url.replace(/.*[?&]id=/, '').replace(/&.*$/, '');
+    return { date, url, key: `${date}/${id}` };
+  }
+}

--- a/app/src/models/monthlyArchive.test.ts
+++ b/app/src/models/monthlyArchive.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { vol } from 'memfs';
+
+vi.mock('fs-extra', () => ({
+  ensureDir: async (p: string) => vol.promises.mkdir(p, { recursive: true }),
+  readFile: vol.promises.readFile,
+  writeFile: vol.promises.writeFile,
+}));
+vi.mock('node:fs/promises', () => vol.promises);
+
+import { saveWallpaper, listWallpapers } from '../repositories/wallpaperRepository.js';
+import { DailyMarkdown } from './dailyMarkdown.js';
+import { MonthlyArchive } from './monthlyArchive.js';
+
+const meta = {
+  previewUrl: 'https://p/prev.jpg',
+  downloadUrl: 'https://p/dl.jpg',
+  bing: { startdate: '20250721', url: 'https://p/dl.jpg', title: 't', copyright: 'c' },
+};
+
+describe('MonthlyArchive', () => {
+  it('computes paths from daily', () => {
+    const daily = new DailyMarkdown('20250721', meta);
+    const month = MonthlyArchive.fromDaily(daily);
+    expect(month.key).toBe('2025-07');
+    expect(month.dir).toBe('archive/2025');
+    expect(month.file).toBe('archive/2025/07.md');
+  });
+
+  it('writes archives and links', async () => {
+    await saveWallpaper(meta, '20250721');
+    const records = await listWallpapers('wallpaper');
+    await MonthlyArchive.writeArchives(records);
+    const text = await vol.promises.readFile('archive/2025/07.md', 'utf8');
+    expect(text).toContain('# 2025-07');
+    const links = await MonthlyArchive.buildLinks();
+    expect(links).toContain('[2025-07](./archive/2025/07.md)');
+  });
+
+  it('transforms body', () => {
+    const res = MonthlyArchive.transformBody('# Title\nfoo');
+    expect(res.startsWith('## Title')).toBe(true);
+  });
+});

--- a/app/src/models/monthlyArchive.ts
+++ b/app/src/models/monthlyArchive.ts
@@ -1,0 +1,77 @@
+import { join } from 'node:path';
+import { readdir, writeFile } from 'node:fs/promises';
+import { ensureDir } from 'fs-extra';
+import { DIR_ARCHIVE } from '../lib/config.js';
+import { DailyMarkdown } from './dailyMarkdown.js';
+import type { WallpaperRecord } from '../repositories/wallpaperRepository.js';
+
+export class MonthlyArchive {
+  constructor(public year: string, public month: string) {}
+
+  static fromKey(key: string): MonthlyArchive {
+    const [y, m] = key.split('-');
+    return new MonthlyArchive(y, m);
+  }
+
+  static fromDaily(daily: DailyMarkdown): MonthlyArchive {
+    return new MonthlyArchive(daily.year, daily.month);
+  }
+
+  get key(): string {
+    return `${this.year}-${this.month}`;
+  }
+
+  get dir(): string {
+    return join(DIR_ARCHIVE, this.year);
+  }
+
+  get file(): string {
+    return join(this.dir, `${this.month}.md`);
+  }
+
+  static transformBody(body: string): string {
+    const lines = body.split(/\r?\n/);
+    const updated = lines
+      .map((l, i) => (i === 0 && l.startsWith('# ') ? `##${l.slice(1)}` : l))
+      .join('\n');
+    return updated + '\n';
+  }
+
+  static group(records: WallpaperRecord[]): Map<string, WallpaperRecord[]> {
+    const map = new Map<string, WallpaperRecord[]>();
+    for (const r of records) {
+      const key = DailyMarkdown.fromRecord(r).monthKey;
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(r);
+    }
+    return map;
+  }
+
+  static async writeArchives(records: WallpaperRecord[]) {
+    const map = MonthlyArchive.group(records);
+    for (const [key, items] of map) {
+      const archive = MonthlyArchive.fromKey(key);
+      await ensureDir(archive.dir);
+      const content = `# ${archive.key}\n\n` +
+        items.map((r) => MonthlyArchive.transformBody(r.body)).join('\n');
+      await writeFile(archive.file, content);
+    }
+  }
+
+  static async buildLinks(): Promise<string> {
+    await ensureDir(DIR_ARCHIVE);
+    const years = await readdir(DIR_ARCHIVE);
+    const links: string[] = [];
+    for (const y of years.sort().reverse()) {
+      const months = await readdir(join(DIR_ARCHIVE, y));
+      months
+        .sort()
+        .reverse()
+        .forEach((m) => {
+          const name = m.replace(/\.md$/, '');
+          links.push(`[${y}-${name}](./${DIR_ARCHIVE}/${y}/${m})`);
+        });
+    }
+    return links.join('\n');
+  }
+}

--- a/app/src/models/readme.test.ts
+++ b/app/src/models/readme.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from 'vitest';
+import { vol } from 'memfs';
+
+vi.mock('node:fs/promises', () => vol.promises);
+
+import { ReadmeFile } from './readme.js';
+
+describe('ReadmeFile', () => {
+  it('updates latest section', async () => {
+    vol.fromJSON({ 'README.md': '# Intro\n\n# Latest wallpapers\n\nold\n\n# Archives\n\nold' });
+    const r = new ReadmeFile('README.md');
+    await r.updateLatestSection('latest', 'links');
+    const text = await vol.promises.readFile('README.md', 'utf8');
+    expect(text).toContain('latest');
+    expect(text).toContain('links');
+  });
+});

--- a/app/src/models/readme.ts
+++ b/app/src/models/readme.ts
@@ -1,0 +1,22 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { PATH_README } from '../lib/config.js';
+
+export class ReadmeFile {
+  constructor(public path = PATH_README) {}
+
+  async read(): Promise<string> {
+    return readFile(this.path, 'utf8');
+  }
+
+  async write(content: string) {
+    await writeFile(this.path, content);
+  }
+
+  async updateLatestSection(latest: string, links: string) {
+    const text = await this.read();
+    const headerIndex = text.indexOf('# Latest wallpapers');
+    const prefix = text.slice(0, headerIndex).trimEnd();
+    const body = `# Latest wallpapers\n\n${latest}\n\n# Archives\n\n${links}\n`;
+    await this.write(`${prefix}\n${body}`);
+  }
+}

--- a/app/src/services/archiveService.ts
+++ b/app/src/services/archiveService.ts
@@ -1,66 +1,17 @@
-import { readFile, writeFile, readdir } from 'node:fs/promises';
-import { join } from 'node:path';
-import { ensureDir } from 'fs-extra';
-
-import { listWallpapers, type WallpaperRecord } from '../repositories/wallpaperRepository.js';
-import { DIR_ARCHIVE, DIR_WALLPAPER, PATH_README } from '../lib/config.js';
-
-function transform(body: string): string {
-  const lines = body.split(/\r?\n/);
-  const updated = lines.map((l, i) =>
-    i === 0 && l.startsWith('# ') ? `##${l.slice(1)}` : l,
-  ).join('\n');
-  return updated + '\n';
-}
-
-function groupByMonth(records: WallpaperRecord[]): Map<string, WallpaperRecord[]> {
-  const map = new Map<string, WallpaperRecord[]>();
-  for (const r of records) {
-    const [year, month] = r.file.split('/');
-    const key = `${year}-${month}`;
-    if (!map.has(key)) map.set(key, []);
-    map.get(key)!.push(r);
-  }
-  return map;
-}
-
-async function buildArchiveLinks(): Promise<string> {
-  await ensureDir(DIR_ARCHIVE)
-  const years = await readdir(DIR_ARCHIVE);
-  const links: string[] = [];
-  for (const y of years.sort().reverse()) {
-    const months = await readdir(join(DIR_ARCHIVE, y));
-    months
-      .sort()
-      .reverse()
-      .forEach((m) => links.push(`[${y}-${m}](./${DIR_ARCHIVE}/${y}/${m})`));
-  }
-  return links.join('\n');
-}
-
-async function writeMonthlyArchives(records: WallpaperRecord[]) {
-  const map = groupByMonth(records);
-  for (const [key, items] of map) {
-    const [y, m] = key.split('-');
-    const dir = join(DIR_ARCHIVE, y);
-    await ensureDir(dir);
-    const content = `# ${key}\n\n` + items.map((r) => transform(r.body)).join('\n');
-    await writeFile(join(dir, `${m}.md`), content);
-  }
-}
+import { listWallpapers } from '../repositories/wallpaperRepository.js';
+import { DIR_WALLPAPER } from '../lib/config.js';
+import { MonthlyArchive } from '../models/monthlyArchive.js';
+import { ReadmeFile } from '../models/readme.js';
 
 export async function buildArchive() {
   const records = await listWallpapers(DIR_WALLPAPER);
-  await writeMonthlyArchives(records);
+  await MonthlyArchive.writeArchives(records);
   const latest = records.slice(0, 10);
-  const latestSection = latest.map((r) => transform(r.body)).join('\n');
+  const latestSection = latest
+    .map((r) => MonthlyArchive.transformBody(r.body))
+    .join('\n');
 
-  const readme = await readFile(PATH_README, 'utf8');
-  const headerIndex = readme.indexOf('# Latest wallpapers');
-  const prefix = readme.slice(0, headerIndex).trimEnd();
-  const links = await buildArchiveLinks();
-  const body = `# Latest wallpapers\n\n${latestSection}\n\n# Archives\n\n${links}\n`;
-  await writeFile(PATH_README, `${prefix}\n${body}`);
-
+  const links = await MonthlyArchive.buildLinks();
+  const readme = new ReadmeFile();
+  await readme.updateLatestSection(latestSection, links);
 }
-

--- a/app/src/services/uploadService.test.ts
+++ b/app/src/services/uploadService.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { vol } from 'memfs';
+
+vi.mock('node:fs/promises', () => vol.promises);
+vi.mock('axios');
+
+const sendMock = vi.fn();
+
+vi.mock('@aws-sdk/client-s3', () => {
+  return {
+    S3Client: vi.fn().mockImplementation(() => ({ send: sendMock })),
+    GetObjectCommand: vi.fn((args) => ({ ...args, __type: 'GetObjectCommand' })),
+    PutObjectCommand: vi.fn((args) => ({ ...args, __type: 'PutObjectCommand' })),
+  };
+});
+
+import { uploadImages } from './uploadService.js';
+
+const sampleBuffer = Buffer.from([0xff, 0xd8, 0xff, 0xd9]);
+
+describe('uploadImages', () => {
+  it('uploads new images and updates cursor', async () => {
+    vol.fromJSON({ 'wallpaper/all.txt': '2025/07/21.md https://img.jpg\n' });
+    const axios = await import('axios');
+    (axios.default.get as any) = vi.fn(async () => ({
+      status: 200,
+      data: sampleBuffer,
+      headers: { 'content-type': 'image/jpeg' },
+    }));
+    sendMock.mockRejectedValueOnce(new Error('not found')); // cursor not exist
+    await uploadImages({ bucket: 'test', client: new (await import('@aws-sdk/client-s3')).S3Client({}) });
+    expect(sendMock).toHaveBeenCalledWith(expect.objectContaining({ __type: 'PutObjectCommand', Bucket: 'test' }));
+  });
+});

--- a/app/src/services/uploadService.ts
+++ b/app/src/services/uploadService.ts
@@ -1,0 +1,62 @@
+import { readFile } from 'node:fs/promises';
+import axios from 'axios';
+import {
+  S3Client,
+  GetObjectCommand,
+  PutObjectCommand,
+} from '@aws-sdk/client-s3';
+import { DailyMarkdown } from '../models/dailyMarkdown.js';
+
+export interface UploadOptions {
+  bucket: string;
+  client?: S3Client;
+  cursorKey?: string;
+  allPath?: string;
+}
+
+async function readCursor(client: S3Client, bucket: string, key: string) {
+  try {
+    const res = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+    const chunks: Buffer[] = [];
+    for await (const chunk of res.Body as any as AsyncIterable<Buffer>) {
+      chunks.push(chunk);
+    }
+    return Buffer.concat(chunks).toString('utf8').trim();
+  } catch {
+    return '';
+  }
+}
+
+async function writeCursor(client: S3Client, bucket: string, key: string, value: string) {
+  await client.send(
+    new PutObjectCommand({ Bucket: bucket, Key: key, Body: value })
+  );
+}
+
+
+export async function uploadImages(options: UploadOptions) {
+  const bucket = options.bucket;
+  if (!bucket) throw new Error('bucket required');
+  const client = options.client || new S3Client({});
+  const cursorKey = options.cursorKey ?? 'cursor.txt';
+  const allPath = options.allPath ?? 'wallpaper/all.txt';
+  const cursor = await readCursor(client, bucket, cursorKey);
+  const lines = (await readFile(allPath, 'utf8'))
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+  let latest = cursor;
+  for (const line of lines) {
+    const { date, url, key } = DailyMarkdown.parseIndexLine(line);
+    if (cursor && date <= cursor) continue;
+    const res = await axios.get(url, { responseType: 'arraybuffer' });
+    if (res.status !== 200 || !res.headers['content-type']?.startsWith('image/')) {
+      throw new Error(`invalid image: ${url}`);
+    }
+    await client.send(
+      new PutObjectCommand({ Bucket: bucket, Key: key, Body: res.data })
+    );
+    latest = date;
+    await writeCursor(client, bucket, cursorKey, latest);
+  }
+}

--- a/app/src/services/wallpaperService.test.ts
+++ b/app/src/services/wallpaperService.test.ts
@@ -8,6 +8,7 @@ vi.mock('fs-extra', () => ({
   readFile: vol.promises.readFile,
   writeFile: vol.promises.writeFile,
 }));
+vi.mock('node:fs/promises', () => vol.promises);
 
 vi.mock('../lib/bing.js', () => ({
   fetchBingImages: vi.fn(() => Promise.resolve([sampleImage]))
@@ -32,10 +33,10 @@ describe('wallpaperService', () => {
   });
 
   it('saves images from migrate plugin', async () => {
-    const fs = await import('fs/promises');
-    const dir = await fs.mkdtemp('/tmp-plugin-');
+    const fs = await import('fs');
+    const dir = await fs.promises.mkdtemp('/tmp-plugin-');
     const pluginPath = `${dir}/p.mjs`;
-    await fs.writeFile(pluginPath, 'export default async () => [' + JSON.stringify(sampleImage) + '];');
+    await fs.promises.writeFile(pluginPath, 'export default async () => [' + JSON.stringify(sampleImage) + '];');
     await migrateWallpapers(pluginPath, 'src');
     const file = wallpaperPath('20250721');
     const text = await vol.promises.readFile(file, 'utf8');

--- a/app/src/services/wallpaperService.ts
+++ b/app/src/services/wallpaperService.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 import { fetchBingImages, BingImage } from '../lib/bing.js';
 import { processImageUrl } from '../lib/url.js';
-import { saveWallpaper, wallpaperPath } from '../repositories/wallpaperRepository.js';
+import { DailyMarkdown } from '../models/dailyMarkdown.js';
 
 export interface SaveOptions {
   force?: boolean;
@@ -10,10 +10,14 @@ export interface SaveOptions {
 
 export async function saveImages(images: BingImage[], opts: SaveOptions = {}) {
   for (const img of images) {
-    const file = wallpaperPath(img.startdate);
-    if (!opts.force && existsSync(file)) continue;
     const { previewUrl, downloadUrl } = processImageUrl(img.url);
-    await saveWallpaper({ previewUrl, downloadUrl, bing: img }, img.startdate);
+    const daily = new DailyMarkdown(img.startdate, {
+      previewUrl,
+      downloadUrl,
+      bing: img,
+    });
+    if (!opts.force && existsSync(daily.file)) continue;
+    await daily.save();
   }
 }
 
@@ -23,7 +27,7 @@ export async function updateWallpapers() {
 }
 
 export async function migrateWallpapers(plugin: string, source: string, opts: SaveOptions = {}) {
-  const mod = await import(pathToFileURL(plugin).href);
+  const mod = await import(/* @vite-ignore */ pathToFileURL(plugin).href);
   const loader: (src: string) => Promise<BingImage[]> = mod.default;
   const images = await loader(source);
   await saveImages(images, opts);


### PR DESCRIPTION
## Summary
- move more path handling into dedicated models
- use `MonthlyArchive` and `ReadmeFile` to update archives and README
- remove archive helpers from `DailyMarkdown`
- test new models

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm coverage`


------
https://chatgpt.com/codex/tasks/task_e_6882926c5de883278173bfda8c771efe