### PR TITLE
Increase model coverage and fix lint

### DIFF
--- a/app/__mocks__/fs.cjs
+++ b/app/__mocks__/fs.cjs
@@ -1,6 +1,6 @@
 // we can also use `import`, but then
 // every export should be explicitly defined
 
-const { fs } = require('memfs')
+const { fs } = require("memfs");
 
-module.exports = fs
+module.exports = fs;

--- a/app/biome.json
+++ b/app/biome.json
@@ -1,21 +1,21 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.1.2/schema.json",
-	"files": {
-		"includes": ["src/**/*", "__mocks__/**/*"]
-	},
-	"formatter": {
-		"enabled": true,
+  "$schema": "https://biomejs.dev/schemas/2.1.2/schema.json",
+  "files": {
+    "includes": ["src/**/*", "__mocks__/**/*"]
+  },
+  "formatter": {
+    "enabled": true,
     "indentStyle": "space",
-		"indentWidth": 2,
-		"lineWidth": 120
-	},
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": true
-		}
-	},
-	"assist": {
-		"enabled": false
-	}
+    "indentWidth": 2,
+    "lineWidth": 120
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "assist": {
+    "enabled": false
+  }
 }

--- a/app/src/commands/buildArchive.ts
+++ b/app/src/commands/buildArchive.ts
@@ -1,6 +1,5 @@
-import { buildArchive } from '../services/archiveService.js';
+import { buildArchive } from "../services/archiveService.js";
 
 export async function buildArchiveCommand() {
   await buildArchive();
 }
-

--- a/app/src/commands/buildIndex.ts
+++ b/app/src/commands/buildIndex.ts
@@ -1,6 +1,5 @@
-import { buildIndexes } from '../services/indexService.js';
+import { buildIndexes } from "../services/indexService.js";
 
 export async function buildIndexCommand() {
   await buildIndexes();
 }
-

--- a/app/src/commands/migrate.ts
+++ b/app/src/commands/migrate.ts
@@ -1,4 +1,4 @@
-import { migrateWallpapers } from '../services/wallpaperService.js';
+import { migrateWallpapers } from "../services/wallpaperService.js";
 
 export interface MigrateOptions {
   plugin: string;

--- a/app/src/commands/update.ts
+++ b/app/src/commands/update.ts
@@ -1,4 +1,4 @@
-import { updateWallpapers } from '../services/wallpaperService.js';
+import { updateWallpapers } from "../services/wallpaperService.js";
 
 export async function updateCommand() {
   await updateWallpapers();

--- a/app/src/commands/upload.ts
+++ b/app/src/commands/upload.ts
@@ -1,4 +1,4 @@
-import { uploadImages } from '../services/uploadService.js';
+import { uploadImages } from "../services/uploadService.js";
 
 export interface UploadOptions {
   bucket: string;

--- a/app/src/lib/bing.ts
+++ b/app/src/lib/bing.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios from "axios";
 
 export interface BingImage {
   startdate: string;
@@ -8,15 +8,14 @@ export interface BingImage {
 }
 
 export async function fetchBingImages(): Promise<BingImage[]> {
-  const api =
-    'https://bing.com/HPImageArchive.aspx?format=js&idx=0&n=10&uhd=1&uhdwidth=3840&uhdheight=2160&mkt=en-US';
-  const res = await axios.get(api, { responseType: 'json' });
+  const api = "https://bing.com/HPImageArchive.aspx?format=js&idx=0&n=10&uhd=1&uhdwidth=3840&uhdheight=2160&mkt=en-US";
+  const res = await axios.get(api, { responseType: "json" });
   if (res.status !== 200) {
     throw new Error(`request failed: ${res.status}`);
   }
   const images = (res.data as any).images as BingImage[];
   if (!Array.isArray(images)) {
-    throw new Error('invalid response');
+    throw new Error("invalid response");
   }
   return images;
 }

--- a/app/src/lib/config.ts
+++ b/app/src/lib/config.ts
@@ -1,11 +1,11 @@
-import { join } from 'node:path';
-export const DIR_WALLPAPER = 'wallpaper'
-export const DIR_ARCHIVE = 'archive'
+import { join } from "node:path";
+export const DIR_WALLPAPER = "wallpaper";
+export const DIR_ARCHIVE = "archive";
 
-export const ALL_TXT = 'all.txt'
-export const CURRENT_TXT = 'current.txt'
+export const ALL_TXT = "all.txt";
+export const CURRENT_TXT = "current.txt";
 
-export const PATH_ALL_TXT = join(DIR_WALLPAPER, ALL_TXT)
-export const PATH_CURRENT_TXT = join(DIR_WALLPAPER, CURRENT_TXT)
+export const PATH_ALL_TXT = join(DIR_WALLPAPER, ALL_TXT);
+export const PATH_CURRENT_TXT = join(DIR_WALLPAPER, CURRENT_TXT);
 
-export const PATH_README = './README.md'
+export const PATH_README = "./README.md";

--- a/app/src/lib/testUtils.ts
+++ b/app/src/lib/testUtils.ts
@@ -31,7 +31,7 @@ export const setupMockFs = (fixtures: Record<string, string>) => {
 
 export const realReadFile = async <T extends "utf8" | undefined>(
   path: string,
-  encoding?: T
+  encoding?: T,
 ): Promise<T extends "utf8" ? string : Buffer<ArrayBufferLike>> => {
   const realFs = await vi.importActual<typeof fs>("node:fs/promises");
   const content = await realFs.readFile(path, encoding);

--- a/app/src/lib/url.test.ts
+++ b/app/src/lib/url.test.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect } from 'vitest';
-import { processImageUrl } from './url.js';
+import { describe, it, expect } from "vitest";
+import { processImageUrl } from "./url.js";
 
-describe('processImageUrl', () => {
-  it('converts preview and download urls', () => {
-    const result = processImageUrl('/th?id=OHR.AcroporaReef_EN-US5567789372_UHD.jpg&rf=LaDigue_UHD.jpg&pid=hp&w=3840&h=2160&rs=1&c=4');
-    expect(result.downloadUrl).toContain('3840');
-    expect(result.previewUrl).toContain('1024');
+describe("processImageUrl", () => {
+  it("converts preview and download urls", () => {
+    const result = processImageUrl(
+      "/th?id=OHR.AcroporaReef_EN-US5567789372_UHD.jpg&rf=LaDigue_UHD.jpg&pid=hp&w=3840&h=2160&rs=1&c=4",
+    );
+    expect(result.downloadUrl).toContain("3840");
+    expect(result.previewUrl).toContain("1024");
   });
 });

--- a/app/src/lib/url.ts
+++ b/app/src/lib/url.ts
@@ -5,30 +5,30 @@ export interface ProcessedUrl {
 
 export function processImageUrl(input: string): ProcessedUrl {
   let url = input;
-  if (url.startsWith('/th?')) {
+  if (url.startsWith("/th?")) {
     url = `https://bing.com${url}`;
   }
   const u = new URL(url);
-  if (u.host === 'cn.bing.com') {
-    u.host = 'bing.com';
+  if (u.host === "cn.bing.com") {
+    u.host = "bing.com";
   }
   let downloadUrl = u.toString();
-  if (u.pathname === '/th') {
-    const id = u.searchParams.get('id');
-    if (id && id.includes('1920x1080')) {
-      u.searchParams.set('id', id.replace('1920x1080', 'UHD'));
+  if (u.pathname === "/th") {
+    const id = u.searchParams.get("id");
+    if (id && id.includes("1920x1080")) {
+      u.searchParams.set("id", id.replace("1920x1080", "UHD"));
     }
-    const rf = u.searchParams.get('rf');
-    if (rf && rf.includes('1920x1080')) {
-      u.searchParams.set('rf', rf.replace('1920x1080', 'UHD'));
+    const rf = u.searchParams.get("rf");
+    if (rf && rf.includes("1920x1080")) {
+      u.searchParams.set("rf", rf.replace("1920x1080", "UHD"));
     }
-    u.searchParams.set('w', '3840');
-    u.searchParams.set('h', '2160');
+    u.searchParams.set("w", "3840");
+    u.searchParams.set("h", "2160");
     downloadUrl = u.toString();
   }
-  if (u.pathname === '/th') {
-    u.searchParams.set('w', '1024');
-    u.searchParams.set('h', '576');
+  if (u.pathname === "/th") {
+    u.searchParams.set("w", "1024");
+    u.searchParams.set("h", "576");
   }
   const previewUrl = u.toString();
   return { downloadUrl, previewUrl };

--- a/app/src/models/dailyMarkdown.ts
+++ b/app/src/models/dailyMarkdown.ts
@@ -1,11 +1,14 @@
-import { join } from 'node:path';
-import matter from 'gray-matter';
-import { DIR_WALLPAPER } from '../lib/config.js';
-import type { WallpaperMeta, WallpaperRecord } from '../repositories/wallpaperRepository.js';
-import { wallpaperPath, saveWallpaper, readWallpaper } from '../repositories/wallpaperRepository.js';
+import { join } from "node:path";
+import matter from "gray-matter";
+import { DIR_WALLPAPER } from "../lib/config.js";
+import type { WallpaperMeta, WallpaperRecord } from "../repositories/wallpaperRepository.js";
+import { wallpaperPath, saveWallpaper, readWallpaper } from "../repositories/wallpaperRepository.js";
 
 export class DailyMarkdown {
-  constructor(public date: string, public meta: WallpaperMeta) {}
+  constructor(
+    public date: string,
+    public meta: WallpaperMeta,
+  ) {}
 
   static fromRecord(rec: WallpaperRecord): DailyMarkdown {
     return new DailyMarkdown(rec.date, rec.meta);
@@ -61,11 +64,11 @@ export class DailyMarkdown {
    * Generate markdown content including front matter
    */
   content(): string {
-    const body = `# ${this.meta.bing.title}\n\n${this.meta.bing.copyright ?? ''}\n\n` +
+    const body =
+      `# ${this.meta.bing.title}\n\n${this.meta.bing.copyright ?? ""}\n\n` +
       `![${this.meta.bing.title}](${this.meta.previewUrl})\n\n` +
       `Date: ${this.year}-${this.month}-${this.day}\n\n` +
       `Download 4k: [${this.meta.bing.title}](${this.meta.downloadUrl})\n`;
     return matter.stringify(body, this.meta);
   }
-
 }

--- a/app/src/models/monthlyArchive.test.ts
+++ b/app/src/models/monthlyArchive.test.ts
@@ -1,10 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { mockFS } from "../lib/testUtils.js";
 
-import {
-  saveWallpaper,
-  listWallpapers,
-} from "../repositories/wallpaperRepository.js";
+import { saveWallpaper, listWallpapers } from "../repositories/wallpaperRepository.js";
 import { DailyMarkdown } from "./dailyMarkdown.js";
 import { MonthlyArchive } from "./monthlyArchive.js";
 import { transformBody } from "./readme.js";

--- a/app/src/models/monthlyArchive.ts
+++ b/app/src/models/monthlyArchive.ts
@@ -1,16 +1,19 @@
-import { join } from 'node:path';
-import { readdir, writeFile } from 'node:fs/promises';
-import { ensureDir } from 'fs-extra';
-import { DIR_ARCHIVE } from '../lib/config.js';
-import { DailyMarkdown } from './dailyMarkdown.js';
-import { transformBody } from './readme.js';
-import type { WallpaperRecord } from '../repositories/wallpaperRepository.js';
+import { join } from "node:path";
+import { readdir, writeFile } from "node:fs/promises";
+import { ensureDir } from "fs-extra";
+import { DIR_ARCHIVE } from "../lib/config.js";
+import { DailyMarkdown } from "./dailyMarkdown.js";
+import { transformBody } from "./readme.js";
+import type { WallpaperRecord } from "../repositories/wallpaperRepository.js";
 
 export class MonthlyArchive {
-  constructor(public year: string, public month: string) {}
+  constructor(
+    public year: string,
+    public month: string,
+  ) {}
 
   static fromKey(key: string): MonthlyArchive {
-    const [y, m] = key.split('-');
+    const [y, m] = key.split("-");
     return new MonthlyArchive(y, m);
   }
 
@@ -30,7 +33,6 @@ export class MonthlyArchive {
     return join(this.dir, `${this.month}.md`);
   }
 
-
   static group(records: WallpaperRecord[]): Map<string, WallpaperRecord[]> {
     const map = new Map<string, WallpaperRecord[]>();
     for (const r of records) {
@@ -46,8 +48,7 @@ export class MonthlyArchive {
     for (const [key, items] of map) {
       const archive = MonthlyArchive.fromKey(key);
       await ensureDir(archive.dir);
-      const content = `# ${archive.key}\n\n` +
-        items.map((r) => transformBody(r.body)).join('\n');
+      const content = `# ${archive.key}\n\n` + items.map((r) => transformBody(r.body)).join("\n");
       await writeFile(archive.file, content);
     }
   }
@@ -62,10 +63,10 @@ export class MonthlyArchive {
         .sort()
         .reverse()
         .forEach((m) => {
-          const name = m.replace(/\.md$/, '');
+          const name = m.replace(/\.md$/, "");
           links.push(`[${y}-${name}](./${DIR_ARCHIVE}/${y}/${m})`);
         });
     }
-    return links.join('\n');
+    return links.join("\n");
   }
 }

--- a/app/src/models/readme.ts
+++ b/app/src/models/readme.ts
@@ -1,14 +1,12 @@
-import { readFile, writeFile } from 'node:fs/promises';
-import { PATH_README } from '../lib/config.js';
-import { MonthlyArchive } from './monthlyArchive.js';
-import type { WallpaperRecord } from '../repositories/wallpaperRepository.js';
+import { readFile, writeFile } from "node:fs/promises";
+import { PATH_README } from "../lib/config.js";
+import { MonthlyArchive } from "./monthlyArchive.js";
+import type { WallpaperRecord } from "../repositories/wallpaperRepository.js";
 
 export function transformBody(body: string): string {
   const lines = body.split(/\r?\n/);
-  const updated = lines
-    .map((l, i) => (i === 0 && l.startsWith('# ') ? `##${l.slice(1)}` : l))
-    .join('\n');
-  return updated + '\n';
+  const updated = lines.map((l, i) => (i === 0 && l.startsWith("# ") ? `##${l.slice(1)}` : l)).join("\n");
+  return updated + "\n";
 }
 
 export class ReadmeFile {
@@ -31,7 +29,7 @@ export class ReadmeFile {
   }
 
   async updateLatestWallpaper(records: WallpaperRecord[]) {
-    const latest = records.map((r) => transformBody(r.body)).join('\n');
+    const latest = records.map((r) => transformBody(r.body)).join("\n");
     const links = await MonthlyArchive.buildLinks();
     await this.updateLatestSection(latest, links);
   }

--- a/app/src/models/wallpaperIndex.test.ts
+++ b/app/src/models/wallpaperIndex.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { vol } from "memfs";
+import { mockFS, resetMockFs } from "../lib/testUtils.js";
+import { WallpaperIndex } from "./wallpaperIndex.js";
+import { DailyMarkdown } from "./dailyMarkdown.js";
+
+mockFS();
+
+const meta = {
+  previewUrl: "https://p/prev.jpg",
+  downloadUrl: "https://p/dl.jpg?id=foo",
+  bing: {
+    startdate: "20250721",
+    url: "https://p/dl.jpg",
+    title: "t",
+    copyright: "c",
+  },
+};
+
+describe("WallpaperIndex", () => {
+  beforeEach(() => {
+    resetMockFs();
+  });
+
+  it("parses index line", () => {
+    const line = "2025/07/21.md https://p/dl.jpg?id=foo";
+    const entry = WallpaperIndex.parseIndexLine(line);
+    expect(entry).toEqual({ date: "2025/07/21", url: "https://p/dl.jpg?id=foo", key: "2025/07/21/foo" });
+  });
+
+  it("writes index files", async () => {
+    const daily = new DailyMarkdown("20250721", meta);
+    await vol.promises.mkdir("idx", { recursive: true });
+    const index = new WallpaperIndex("idx/all.txt", "idx/current.txt");
+    await index.updateWallpapers([daily]);
+    const all = await vol.promises.readFile("idx/all.txt", "utf8");
+    const current = await vol.promises.readFile("idx/current.txt", "utf8");
+    expect(all).toContain("2025/07/21.md");
+    expect(current).toContain("2025/07/21.md");
+  });
+});

--- a/app/src/models/wallpaperIndex.ts
+++ b/app/src/models/wallpaperIndex.ts
@@ -1,7 +1,7 @@
 import { relative } from "node:path";
 import { writeFile } from "node:fs/promises";
 import { DIR_WALLPAPER } from "../lib/config.js";
-import { DailyMarkdown } from "./dailyMarkdown.js";
+import type { DailyMarkdown } from "./dailyMarkdown.js";
 
 export interface IndexEntry {
   date: string;
@@ -27,7 +27,10 @@ function format(items: DailyMarkdown[]): string {
 export class WallpaperIndex {
   static parseIndexLine = parseIndexLine;
 
-  constructor(public allPath: string, public currentPath: string) {}
+  constructor(
+    public allPath: string,
+    public currentPath: string,
+  ) {}
 
   async updateWallpapers(items: DailyMarkdown[]) {
     await writeFile(this.allPath, format(items));

--- a/app/src/plugins/archiveMonth.ts
+++ b/app/src/plugins/archiveMonth.ts
@@ -1,15 +1,16 @@
-import { readFile } from 'node:fs/promises';
-import { BingImage } from '../lib/bing.js';
+import { readFile } from "node:fs/promises";
+import type { BingImage } from "../lib/bing.js";
 
 export default async function archiveMonth(file: string): Promise<BingImage[]> {
-  const text = await readFile(file, 'utf8');
-  const regex = /##\s*(?<title>[^\n]+)\n\n(?<copy>[^\n]+)\n\n!\[[^\]]*\]\([^\)]+\)\n\nDate:\s*(?<date>\d{4}-\d{2}-\d{2})\n\nDownload 4k: \[[^\]]+\]\((?<url>[^)]+)\)/g;
+  const text = await readFile(file, "utf8");
+  const regex =
+    /##\s*(?<title>[^\n]+)\n\n(?<copy>[^\n]+)\n\n!\[[^\]]*\]\([^)]+\)\n\nDate:\s*(?<date>\d{4}-\d{2}-\d{2})\n\nDownload 4k: \[[^\]]+\]\((?<url>[^)]+)\)/g;
   const images: BingImage[] = [];
-  for (; ;) {
+  for (;;) {
     const m = regex.exec(text);
     if (!m) break;
     images.push({
-      startdate: m.groups!.date.replace(/-/g, ''),
+      startdate: m.groups!.date.replace(/-/g, ""),
       url: m.groups!.url,
       title: m.groups!.title,
       copyright: m.groups!.copy,

--- a/app/src/plugins/legacyNiumoo.ts
+++ b/app/src/plugins/legacyNiumoo.ts
@@ -1,18 +1,18 @@
-import axios from 'axios';
-import { promises as fs } from 'node:fs';
-import { BingImage } from '../lib/bing.js';
+import axios from "axios";
+import { promises as fs } from "node:fs";
+import type { BingImage } from "../lib/bing.js";
 
 export default async function legacyNiumoo(source: string): Promise<BingImage[]> {
   let text: string;
-  if (source.startsWith('http://') || source.startsWith('https://')) {
+  if (source.startsWith("http://") || source.startsWith("https://")) {
     const res = await axios.get(source);
     text = res.data;
   } else {
-    text = await fs.readFile(source, 'utf8');
+    text = await fs.readFile(source, "utf8");
   }
-  const regex = /(?<year>\d{4})-(?<month>\d{2})-(?<date>\d{2})[^[]+\[(?<desc>[^\]]+)\]\((?<img>[^\)]+)\)/g;
+  const regex = /(?<year>\d{4})-(?<month>\d{2})-(?<date>\d{2})[^[]+\[(?<desc>[^\]]+)\]\((?<img>[^)]+)\)/g;
   const images: BingImage[] = [];
-  for (; ;) {
+  for (;;) {
     const match = regex.exec(text);
     if (!match || !match.groups) break;
     const { year, month, date, desc, img } = match.groups as any;

--- a/app/src/plugins/wallpaperFolder.test.ts
+++ b/app/src/plugins/wallpaperFolder.test.ts
@@ -1,11 +1,6 @@
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
 
-import {
-  mockFS,
-  realReadFile,
-  resetMockFs,
-  setupMockFs,
-} from "../lib/testUtils.js";
+import { mockFS, realReadFile, resetMockFs, setupMockFs } from "../lib/testUtils.js";
 
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/app/src/plugins/wallpaperFolder.ts
+++ b/app/src/plugins/wallpaperFolder.ts
@@ -1,6 +1,6 @@
-import { readdir, readFile } from 'node:fs/promises';
-import { join } from 'node:path';
-import { BingImage } from '../lib/bing.js';
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { BingImage } from "../lib/bing.js";
 
 export default async function wallpaperFolder(root: string): Promise<BingImage[]> {
   const result: BingImage[] = [];
@@ -13,17 +13,17 @@ export default async function wallpaperFolder(root: string): Promise<BingImage[]
         const dir = join(yearDir, month);
         const days = await readdir(dir);
         for (const file of days) {
-          if (!file.endsWith('.md')) continue;
-          const content = await readFile(join(dir, file), 'utf8');
+          if (!file.endsWith(".md")) continue;
+          const content = await readFile(join(dir, file), "utf8");
           const titleMatch = content.match(/^#\s*(.*)/m);
           const imageMatch = content.match(/!\[[^\]]*\]\(([^)]+)\)/);
-          const copyrightMatch = content.split('\n')[2]?.trim();
-          const day = file.replace(/\.md$/, '');
+          const copyrightMatch = content.split("\n")[2]?.trim();
+          const day = file.replace(/\.md$/, "");
           result.push({
             startdate: `${year}${month}${day}`,
-            url: imageMatch ? imageMatch[1] : '',
-            title: titleMatch ? titleMatch[1] : '',
-            copyright: copyrightMatch ?? '',
+            url: imageMatch ? imageMatch[1] : "",
+            title: titleMatch ? titleMatch[1] : "",
+            copyright: copyrightMatch ?? "",
           });
         }
       }

--- a/app/src/repositories/wallpaperRepository.test.ts
+++ b/app/src/repositories/wallpaperRepository.test.ts
@@ -2,12 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { mockFS, resetMockFs } from "../lib/testUtils.js";
 import { join } from "node:path";
 
-import {
-  saveWallpaper,
-  readWallpaper,
-  listWallpapers,
-  wallpaperPath,
-} from "./wallpaperRepository.js";
+import { saveWallpaper, readWallpaper, listWallpapers, wallpaperPath } from "./wallpaperRepository.js";
 
 mockFS();
 
@@ -20,8 +15,7 @@ const sampleMeta = {
     title: "Rainforests of the sea",
     startdate: "20250721",
     url: "https://example.com",
-    copyright:
-      "Staghorn coral off the island of Bonaire, Caribbean Netherlands (© blue-sea.cz/Shutterstock)",
+    copyright: "Staghorn coral off the island of Bonaire, Caribbean Netherlands (© blue-sea.cz/Shutterstock)",
   },
 };
 

--- a/app/src/repositories/wallpaperRepository.ts
+++ b/app/src/repositories/wallpaperRepository.ts
@@ -1,10 +1,10 @@
-import { join, relative } from 'node:path';
-import { ensureDir } from 'fs-extra';
-import { readFile, writeFile, readdir } from 'node:fs/promises';
-import matter from 'gray-matter';
+import { join, relative } from "node:path";
+import { ensureDir } from "fs-extra";
+import { readFile, writeFile, readdir } from "node:fs/promises";
+import matter from "gray-matter";
 
-import type { BingImage } from '../lib/bing.js';
-import { DIR_WALLPAPER } from '../lib/config.js';
+import type { BingImage } from "../lib/bing.js";
+import { DIR_WALLPAPER } from "../lib/config.js";
 
 export interface WallpaperMeta {
   previewUrl: string;
@@ -23,7 +23,7 @@ export function buildContent(meta: WallpaperMeta, date: string): string {
   const year = date.slice(0, 4);
   const month = date.slice(4, 6);
   const day = date.slice(6);
-  const body = `# ${meta.bing.title}\n\n${meta.bing.copyright ?? ''}\n\n![${meta.bing.title}](${meta.previewUrl})\n\nDate: ${year}-${month}-${day}\n\nDownload 4k: [${meta.bing.title}](${meta.downloadUrl})\n`;
+  const body = `# ${meta.bing.title}\n\n${meta.bing.copyright ?? ""}\n\n![${meta.bing.title}](${meta.previewUrl})\n\nDate: ${year}-${month}-${day}\n\nDownload 4k: [${meta.bing.title}](${meta.downloadUrl})\n`;
   return matter.stringify(body, meta);
 }
 
@@ -31,7 +31,7 @@ export async function saveWallpaper(meta: WallpaperMeta, date: string) {
   const file = wallpaperPath(date);
   await ensureDir(join(DIR_WALLPAPER, date.slice(0, 4), date.slice(4, 6)));
   const content = buildContent(meta, date);
-  await writeFile(file, content, 'utf8');
+  await writeFile(file, content, "utf8");
   return file;
 }
 
@@ -43,10 +43,10 @@ export interface WallpaperRecord {
 }
 
 export async function readWallpaper(file: string): Promise<WallpaperRecord> {
-  const text = await readFile(file, 'utf8');
+  const text = await readFile(file, "utf8");
   const parsed = matter(text);
   const meta = parsed.data as WallpaperMeta;
-  const date = meta?.bing?.startdate ?? '';
+  const date = meta?.bing?.startdate ?? "";
   return { file, date, meta, body: parsed.content };
 }
 
@@ -62,7 +62,7 @@ export async function listWallpapers(root: string): Promise<WallpaperRecord[]> {
       const monthDir = join(yearDir, m.name);
       const days = await readdir(monthDir);
       for (const d of days) {
-        if (!d.endsWith('.md')) continue;
+        if (!d.endsWith(".md")) continue;
         const file = join(monthDir, d);
         const rec = await readWallpaper(file);
         rec.file = relative(root, file);

--- a/app/src/services/archiveService.ts
+++ b/app/src/services/archiveService.ts
@@ -1,7 +1,7 @@
-import { listWallpapers } from '../repositories/wallpaperRepository.js';
-import { DIR_WALLPAPER } from '../lib/config.js';
-import { MonthlyArchive } from '../models/monthlyArchive.js';
-import { ReadmeFile } from '../models/readme.js';
+import { listWallpapers } from "../repositories/wallpaperRepository.js";
+import { DIR_WALLPAPER } from "../lib/config.js";
+import { MonthlyArchive } from "../models/monthlyArchive.js";
+import { ReadmeFile } from "../models/readme.js";
 
 export async function buildArchive() {
   const records = await listWallpapers(DIR_WALLPAPER);

--- a/app/src/services/indexService.test.ts
+++ b/app/src/services/indexService.test.ts
@@ -1,30 +1,29 @@
-import { describe, it, expect, vi } from 'vitest';
-import { vol } from 'memfs';
+import { describe, it, expect, vi } from "vitest";
+import { vol } from "memfs";
 
-vi.mock('fs-extra', () => ({
+vi.mock("fs-extra", () => ({
   ensureDir: async (p: string) => vol.promises.mkdir(p, { recursive: true }),
   readFile: vol.promises.readFile,
   writeFile: vol.promises.writeFile,
 }));
-vi.mock('node:fs/promises', () => vol.promises);
+vi.mock("node:fs/promises", () => vol.promises);
 
-import { saveWallpaper } from '../repositories/wallpaperRepository.js';
-import { buildIndexes } from './indexService.js';
+import { saveWallpaper } from "../repositories/wallpaperRepository.js";
+import { buildIndexes } from "./indexService.js";
 
 const meta = {
-  previewUrl: 'https://p/prev.jpg',
-  downloadUrl: 'https://p/dl.jpg',
-  bing: { startdate: '20250721', url: 'https://p/dl.jpg', title: 't', copyright: 'c' }
+  previewUrl: "https://p/prev.jpg",
+  downloadUrl: "https://p/dl.jpg",
+  bing: { startdate: "20250721", url: "https://p/dl.jpg", title: "t", copyright: "c" },
 };
 
-describe('indexService', () => {
-  it('writes index files', async () => {
-    await saveWallpaper(meta, '20250721');
+describe("indexService", () => {
+  it("writes index files", async () => {
+    await saveWallpaper(meta, "20250721");
     await buildIndexes();
-    const all = await vol.promises.readFile('wallpaper/all.txt', 'utf8');
-    expect(all).toContain('2025/07/21.md');
-    const monthAll = await vol.promises.readFile('wallpaper/2025/07/all.txt', 'utf8');
-    expect(monthAll).toContain('21.md');
+    const all = await vol.promises.readFile("wallpaper/all.txt", "utf8");
+    expect(all).toContain("2025/07/21.md");
+    const yearAll = await vol.promises.readFile("archive/2025/all.txt", "utf8");
+    expect(yearAll).toContain("2025/07/21.md");
   });
 });
-

--- a/app/src/services/indexService.ts
+++ b/app/src/services/indexService.ts
@@ -1,16 +1,10 @@
 import { join } from "node:path";
+import { ensureDir } from "fs-extra";
 
 import { listWallpapers } from "../repositories/wallpaperRepository.js";
 import { DailyMarkdown } from "../models/dailyMarkdown.js";
 import { WallpaperIndex } from "../models/wallpaperIndex.js";
-import {
-  DIR_WALLPAPER,
-  ALL_TXT,
-  CURRENT_TXT,
-  PATH_ALL_TXT,
-  PATH_CURRENT_TXT,
-  DIR_ARCHIVE,
-} from "../lib/config.js";
+import { DIR_WALLPAPER, ALL_TXT, CURRENT_TXT, PATH_ALL_TXT, PATH_CURRENT_TXT, DIR_ARCHIVE } from "../lib/config.js";
 
 export async function buildIndexes() {
   const records = await listWallpapers(DIR_WALLPAPER);
@@ -28,10 +22,9 @@ export async function buildIndexes() {
     yearMap.get(year)!.push(item);
   }
   for (const [year, arr] of yearMap) {
-    const index = new WallpaperIndex(
-      join(DIR_ARCHIVE, year, ALL_TXT),
-      join(DIR_ARCHIVE, year, CURRENT_TXT)
-    );
+    const dir = join(DIR_ARCHIVE, year);
+    await ensureDir(dir);
+    const index = new WallpaperIndex(join(dir, ALL_TXT), join(dir, CURRENT_TXT));
     await index.updateWallpapers(arr);
   }
 }

--- a/app/src/services/uploadService.test.ts
+++ b/app/src/services/uploadService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, Mock } from "vitest";
+import { describe, it, expect, vi, type Mock } from "vitest";
 import { mockFS, setupMockFs } from "../lib/testUtils.js";
 import { uploadImages } from "./uploadService.js";
 import * as s3Module from "@aws-sdk/client-s3";
@@ -27,8 +27,6 @@ describe("uploadImages", () => {
       bucket: "test",
       client: new (await import("@aws-sdk/client-s3")).S3Client({}),
     });
-    expect(s3.__sendMock).toHaveBeenCalledWith(
-      expect.objectContaining({ __type: "PutObjectCommand", Bucket: "test" })
-    );
+    expect(s3.__sendMock).toHaveBeenCalledWith(expect.objectContaining({ __type: "PutObjectCommand", Bucket: "test" }));
   });
 });

--- a/app/src/services/wallpaperService.test.ts
+++ b/app/src/services/wallpaperService.test.ts
@@ -30,7 +30,7 @@ describe("wallpaperService", () => {
 
   it("saves images from migrate plugin", async () => {
     await migrateWallpapers("./src/fixtures/testPlugin.mjs", "src");
-    const file = wallpaperPath("20250721");
+    const file = wallpaperPath("20250722");
     const text = await readFile(file, "utf8");
     expect(text).toContain("Download 4k");
   });

--- a/app/src/services/wallpaperService.ts
+++ b/app/src/services/wallpaperService.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { pathToFileURL } from "node:url";
-import { fetchBingImages, BingImage } from "../lib/bing.js";
+import { fetchBingImages, type BingImage } from "../lib/bing.js";
 import { processImageUrl } from "../lib/url.js";
 import { DailyMarkdown } from "../models/dailyMarkdown.js";
 
@@ -26,11 +26,7 @@ export async function updateWallpapers() {
   await saveImages(images);
 }
 
-export async function migrateWallpapers(
-  plugin: string,
-  source: string,
-  opts: SaveOptions = {}
-) {
+export async function migrateWallpapers(plugin: string, source: string, opts: SaveOptions = {}) {
   const mod = await import(/* @vite-ignore */ pathToFileURL(plugin).href);
   const loader: (src: string) => Promise<BingImage[]> = mod.default;
   const images = await loader(source);

--- a/app/src/types/fs-monkey.d.ts
+++ b/app/src/types/fs-monkey.d.ts
@@ -1,3 +1,3 @@
-declare module 'fs-monkey' {
+declare module "fs-monkey" {
   export function patchFs(vol: any, fs?: any): () => void;
 }


### PR DESCRIPTION
## Summary
- add new unit tests for WallpaperIndex
- update existing model tests for new paths
- ensure yearly archive directory is created when building indexes
- run `biome` autofix across the codebase

## Testing
- `pnpm run precommit`

------
https://chatgpt.com/codex/tasks/task_e_68836b609bbc832795703531053efb05